### PR TITLE
Added native Cronjob to Nextcloud

### DIFF
--- a/nextcloud/docker-compose.yaml
+++ b/nextcloud/docker-compose.yaml
@@ -55,6 +55,17 @@ services:
     networks:
       - traefik_proxy
       - default
+      
+  nextcloud-cron:
+    image: nextcloud
+    restart: always
+    volumes:
+      - /var/docker/nextcloud/app:/var/www/html
+      # - EXTERNES DATENVERZEICHNIS:/var/www/html/data
+    entrypoint: /cron.sh
+    depends_on:
+      - nextcloud-db
+      - nextcloud-redis
     
 networks:
   traefik_proxy:


### PR DESCRIPTION
Official Nextcloud Docker-Image has an inbuilt feature to run cronjobs.
Remember to switch from AJAX to Cron in Settings after installation. Performance boost is huge, especially in larger environments.
[See also](https://github.com/nextcloud/docker/blob/master/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml)