### PR TITLE
Fixes for 19.0.1 & Redis:latest

### DIFF
--- a/nextcloud/docker-compose.yaml
+++ b/nextcloud/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
     networks:
         - default
     restart: always
+    command: redis-server --requirepass YOURPASSWORD # Redis Passwort wählen
     
   nextcloud-app:
     image: nextcloud
@@ -35,6 +36,7 @@ services:
       - nextcloud-redis
     environment:
         REDIS_HOST: nextcloud-redis
+        REDIS_HOST_PASSWORD: YOURPASSWORD # Redis Passwort von oben
     volumes: 
       - /var/docker/nextcloud/app:/var/www/html
       # - EXTERNES DATENVERZEICHNIS:/var/www/html/data 


### PR DESCRIPTION
In the recent update for redis setting a password has become mandatory in order to protect from ongoing attacks called "Meow".
Updating the stack to nextcloud:19.0.1 leads to "Internal Server Error" which is fixed by that.